### PR TITLE
Viewport Height is given to ScrollHelper with respect to ownerHeight

### DIFF
--- a/src/FixedDataTable.react.js
+++ b/src/FixedDataTable.react.js
@@ -291,13 +291,24 @@ var FixedDataTable = React.createClass({
     };
   },
 
-  getInitialState() /*object*/ {
-    var props = this.props;
-    var viewportHeight =
-      (props.height === undefined ? props.maxHeight : props.height) -
+  getViewportHeightFromProps(/*object*/ props) /*number*/ {
+    var totalHeight = props.height === undefined ? props.maxHeight
+                                                 : props.height;
+    if (props.ownerHeight) {
+      totalHeight = Math.min(props.ownerHeight, totalHeight)
+    }
+
+    return (
+      totalHeight -
       (props.headerHeight || 0) -
       (props.footerHeight || 0) -
-      (props.groupHeaderHeight || 0);
+      (props.groupHeaderHeight || 0)
+    );
+  },
+
+  getInitialState() /*object*/ {
+    var props = this.props;
+    var viewportHeight = this.getViewportHeightFromProps(props);
     this._scrollHelper = new FixedDataTableScrollHelper(
       props.rowsCount,
       props.rowHeight,
@@ -801,11 +812,7 @@ var FixedDataTable = React.createClass({
     if (oldState && props.rowsCount !== oldState.rowsCount) {
       // Number of rows changed, try to scroll to the row from before the
       // change
-      var viewportHeight =
-        (props.height === undefined ? props.maxHeight : props.height) -
-        (props.headerHeight || 0) -
-        (props.footerHeight || 0) -
-        (props.groupHeaderHeight || 0);
+      var viewportHeight = this.getViewportHeightFromProps(props);
       this._scrollHelper = new FixedDataTableScrollHelper(
         props.rowsCount,
         props.rowHeight,
@@ -890,6 +897,10 @@ var FixedDataTable = React.createClass({
 
     var useMaxHeight = props.height === undefined;
     var height = Math.round(useMaxHeight ? props.maxHeight : props.height);
+    if (props.ownerHeight) {
+      height = Math.min(props.ownerHeight, height);
+    }
+
     var totalHeightReserved = props.footerHeight + props.headerHeight +
       groupHeaderHeight + 2 * BORDER_HEIGHT;
     var bodyHeight = height - totalHeightReserved;


### PR DESCRIPTION
Fixes issue with FixedDataTableScrollHelper.scrollRowIntoView not
correctly targeting row (because it thinks the viewable area is greater
than owner height)